### PR TITLE
fix: Populate subdomain on import

### DIFF
--- a/internal/provider/resource_dns_record.go
+++ b/internal/provider/resource_dns_record.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -23,6 +24,22 @@ type DnsRecordResourceModel struct {
 	Domain    types.String `tfsdk:"domain"`
 	Subdomain types.String `tfsdk:"subdomain"`
 	DnsRecordModel
+}
+
+func (m *DnsRecordResourceModel) Fill(ctx context.Context, record apiclient.DnsRecord) (diags diag.Diagnostics) {
+	diags.Append(m.DnsRecordModel.Fill(ctx, record)...)
+	if diags.HasError() {
+		return
+	}
+
+	fullName := strings.TrimSuffix(m.Name.ValueString(), ".")
+	domain := strings.TrimSuffix(m.Domain.ValueString(), ".")
+	if fullName == domain {
+		m.Subdomain = types.StringNull()
+	} else if suffix := "." + domain; strings.HasSuffix(fullName, suffix) {
+		m.Subdomain = types.StringValue(strings.TrimSuffix(fullName, suffix))
+	}
+	return
 }
 
 func NewDnsRecordResource() resource.Resource {

--- a/internal/provider/resource_dns_record_test.go
+++ b/internal/provider/resource_dns_record_test.go
@@ -10,7 +10,9 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/jianyuan/terraform-provider-porkbun/internal/acctest"
 	"github.com/jianyuan/terraform-provider-porkbun/internal/apiclient"
@@ -70,6 +72,22 @@ func TestAccDnsRecordResource(t *testing.T) {
 	rn := "porkbun_dns_record.test"
 	content := acctest.RandomWithPrefix("tf")
 
+	subdomainConfig := testAccDnsRecordResourceConfig(fmt.Sprintf(`
+		subdomain = "%[1]s"
+		type      = "TXT"
+		content   = "%[1]s"
+	`, content))
+	wildcardConfig := testAccDnsRecordResourceConfig(fmt.Sprintf(`
+		subdomain = "*"
+		type      = "TXT"
+		content   = "%[1]s"
+		ttl       = 300
+	`, content))
+
+	emptyPlan := resource.ConfigPlanChecks{
+		PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+	}
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -88,11 +106,7 @@ func TestAccDnsRecordResource(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccDnsRecordResourceConfig(fmt.Sprintf(`
-					subdomain = "%[1]s"
-					type      = "TXT"
-					content   = "%[1]s"
-				`, content)),
+				Config: subdomainConfig,
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(rn, tfjsonpath.New("subdomain"), knownvalue.StringExact(content)),
 					statecheck.ExpectKnownValue(rn, tfjsonpath.New("name"), knownvalue.StringExact(content+"."+acctest.TestDomain)),
@@ -100,6 +114,17 @@ func TestAccDnsRecordResource(t *testing.T) {
 					statecheck.ExpectKnownValue(rn, tfjsonpath.New("content"), knownvalue.StringExact(content)),
 					statecheck.ExpectKnownValue(rn, tfjsonpath.New("ttl"), knownvalue.Int64Exact(600)),
 				},
+			},
+			{
+				Config:             subdomainConfig,
+				ResourceName:       rn,
+				ImportState:        true,
+				ImportStateIdFunc:  testAccDnsRecordImportStateIdFunc(rn),
+				ImportStatePersist: true,
+			},
+			{
+				Config:           subdomainConfig,
+				ConfigPlanChecks: emptyPlan,
 			},
 			{
 				Config: testAccDnsRecordResourceConfig(fmt.Sprintf(`
@@ -116,12 +141,7 @@ func TestAccDnsRecordResource(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccDnsRecordResourceConfig(fmt.Sprintf(`
-					subdomain = "*"
-					type      = "TXT"
-					content   = "%[1]s"
-					ttl       = 300
-				`, content)),
+				Config: wildcardConfig,
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(rn, tfjsonpath.New("subdomain"), knownvalue.StringExact("*")),
 					statecheck.ExpectKnownValue(rn, tfjsonpath.New("name"), knownvalue.StringExact("*."+acctest.TestDomain)),
@@ -130,8 +150,29 @@ func TestAccDnsRecordResource(t *testing.T) {
 					statecheck.ExpectKnownValue(rn, tfjsonpath.New("ttl"), knownvalue.Int64Exact(300)),
 				},
 			},
+			{
+				Config:             wildcardConfig,
+				ResourceName:       rn,
+				ImportState:        true,
+				ImportStateIdFunc:  testAccDnsRecordImportStateIdFunc(rn),
+				ImportStatePersist: true,
+			},
+			{
+				Config:           wildcardConfig,
+				ConfigPlanChecks: emptyPlan,
+			},
 		},
 	})
+}
+
+func testAccDnsRecordImportStateIdFunc(rn string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[rn]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", rn)
+		}
+		return fmt.Sprintf("%s_%s_%s", rs.Primary.ID, rs.Primary.Attributes["domain"], rs.Primary.Attributes["type"]), nil
+	}
 }
 
 func testAccDnsRecordResourceConfig(extras string) string {


### PR DESCRIPTION
Closes #85.

## Summary

`ImportState` only sets `id`, `domain`, and `type` from the import string. The post-import `Read` calls `DnsRecordModel.Fill`, which doesn't touch `subdomain` because Porkbun's API only returns the FQDN. State ends up with `subdomain = null`, so the next plan force-replaces every non-apex record.

This PR derives `subdomain` from the API-returned FQDN minus the configured `domain` after `Fill`. Apex (`name == domain`) → `null`, wildcard (`*.example.com`) → `*`, trailing dots are trimmed defensively. Centralised on `DnsRecordResourceModel.Fill` so Create / Update / Read all benefit.

